### PR TITLE
Update hunting.rules

### DIFF
--- a/hunting.rules
+++ b/hunting.rules
@@ -137,7 +137,7 @@ alert tcp any any -> any [25,587] (msg:"TGI HUNT Suspicious x-mailer Blat"; flow
 
 alert tcp any any -> any any (msg:"TGI HUNT netsh firewall"; flow:established; content:"netsh firewall"; threshold:type limit, track by_src, seconds 60, count 1; classtype:bad-unknown; sid:2610330; rev:1;)
 
-alert ip any any -> any any (msg:"TGI HUNT netsh advfirewall"; flow:established; content:"netsh advfirewall"; content:!"This example shows  how to disable Wmi fixed port"; distance:-730; within: 50; content:!"from administrator command prompt window"; distance:22; within:45; threshold:type limit, track by_src, seconds 60, count 1; sid:2610332; rev:1;)
+alert ip any any -> any any (msg:"TGI HUNT netsh advfirewall"; flow:established; content:"netsh advfirewall"; content:!"This example shows  how to disable Wmi fixed port"; distance:-730; within: 50; content:!"from administrator command prompt window"; distance:22; within:45; threshold:type limit, track by_src, seconds 60, count 1; classtype:bad-unknown; sid:2610332; rev:1;)
 
 alert tcp any any -> any any (msg:"TGI HUNT WMIC Prompt"; flow:established; content:"wmic|3a|root|5c|cli>"; threshold:type limit, track by_src, seconds 60, count 1; classtype:bad-unknown; sid:2610336; rev:1;)
 


### PR DESCRIPTION
Assigning a classtype to the only rule that does not have one

Thank you Travis Green for hosting this like this

I am just getting into 'suricata-update' after using OPNSense for a little bit, have been tracking down the classification.config and classtype detail to get the 1/2/3/4/... (to 255?) priority/severity set so that CrowdSec only blocks what I expect it to

The extra detail is to help explain why I happened to find this in the first place and to hopefully verify my understanding of classtype -> classification -> priority/severity is correct. Thank you again!